### PR TITLE
fix: aud should be the FHIR resource server

### DIFF
--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -19,9 +19,9 @@ module.exports.authorizeHandler = async (requestQuerystring) => {
 	
 	//Validate the "aud" parameter as part of the SMART launch framework requirements. If it's not included, or it's not matching the our audience value, reject the request.
 	var audParam = requestQuerystring.aud;
-	if(!audParam || audParam != process.env.GATEWAY_URL) {
+	if(!audParam || audParam !== process.env.EXPECTED_AUD_VALUE) {
 		console.log('An invalid audience was specified on the authorize request.');
-		console.log('Required aud:' + process.env.GATEWAY_URL)
+		console.log('Required aud:' + process.env.EXPECTED_AUD_VALUE)
 		console.log('Actual Aud:' + audParam)
 		return {
 			statusCode: 400,

--- a/lib/mock_patient_service.js
+++ b/lib/mock_patient_service.js
@@ -6,7 +6,7 @@
 module.exports.mockPatientServiceHandler = async () => {
 	return [
 		{patient_id: 'Patient/57ca5687-e198-4b36-9a44-e9460debc611', patient_name: 'Sherlock Holmes (31) (reference)'},
-		{patient_id: 'https://my.ehr.com/Patient/81f65d61-8f91-4472-b668-0efc0aceb0f2', patient_name: 'Mycroft Holmes (38) (full url)'},
+		{patient_id: 'https://yourFHIRserver.com/Patient/81f65d61-8f91-4472-b668-0efc0aceb0f2', patient_name: 'Mycroft Holmes (38) (full url)'},
 		{patient_id: 'Patient/7f344d58-113d-45aa-88cf-c74d8e925d1d', patient_name: 'John Watson (34) (reference)'},
 		{patient_id: 'https://fake.ehr.com/Patient/external', patient_name: '	Sir Arthur Conan Doyle (68) (external patient)'},
 	]

--- a/lib/mock_patient_service.js
+++ b/lib/mock_patient_service.js
@@ -5,8 +5,9 @@
 // In a real implementation, this service would make an API call to an internal fine grained authorization service.
 module.exports.mockPatientServiceHandler = async () => {
 	return [
-		{patient_id: '1440422', patient_name: 'Samuel Ortiz (31)'},
-		{patient_id: '92e12467-e074-4349-a6d4-e88be191b39b', patient_name: 'Amberly Bahringer (65)'},
-		{patient_id: 'c769110f-4d4e-4375-a706-c5d78f729544', patient_name: 'Jann Ferry (63)'}
+		{patient_id: 'Patient/57ca5687-e198-4b36-9a44-e9460debc611', patient_name: 'Sherlock Holmes (31) (reference)'},
+		{patient_id: 'https://dris0ewq9i.execute-api.us-west-2.amazonaws.com/dev/Patient/81f65d61-8f91-4472-b668-0efc0aceb0f2', patient_name: 'Mycroft Holmes (38) (full url)'},
+		{patient_id: 'Patient/7f344d58-113d-45aa-88cf-c74d8e925d1d', patient_name: 'John Watson (34) (reference)'},
+		{patient_id: 'https://fake.ehr.com/Patient/external', patient_name: '	Sir Arthur Conan Doyle (68) (external patient)'},
 	]
 }

--- a/lib/mock_patient_service.js
+++ b/lib/mock_patient_service.js
@@ -6,7 +6,7 @@
 module.exports.mockPatientServiceHandler = async () => {
 	return [
 		{patient_id: 'Patient/57ca5687-e198-4b36-9a44-e9460debc611', patient_name: 'Sherlock Holmes (31) (reference)'},
-		{patient_id: 'https://dris0ewq9i.execute-api.us-west-2.amazonaws.com/dev/Patient/81f65d61-8f91-4472-b668-0efc0aceb0f2', patient_name: 'Mycroft Holmes (38) (full url)'},
+		{patient_id: 'https://my.ehr.com/Patient/81f65d61-8f91-4472-b668-0efc0aceb0f2', patient_name: 'Mycroft Holmes (38) (full url)'},
 		{patient_id: 'Patient/7f344d58-113d-45aa-88cf-c74d8e925d1d', patient_name: 'John Watson (34) (reference)'},
 		{patient_id: 'https://fake.ehr.com/Patient/external', patient_name: '	Sir Arthur Conan Doyle (68) (external patient)'},
 	]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "uuid": "^8.3.0"
   },
   "devDependencies": {
-    "serverless-apigateway-service-proxy": "^1.10.0"
+    "serverless-apigateway-service-proxy": "^1.10.0",
+    "serverless": "^1.73.1"
   }
 }

--- a/serverless.aws.example.yml
+++ b/serverless.aws.example.yml
@@ -32,6 +32,7 @@ provider:
     AUTHZ_SERVER: your_authz_server_id
     OKTA_ORG: youroktaorg.oktapreview.com
     STATE_COOKIE_SIGNATURE_KEY: JustPutAReallyLongValueHere!
+    EXPECTED_AUD_VALUE: https://yourFHIRserver.com
     
     #TODO: Get rid of.
     API_KEY: your_api_key_here


### PR DESCRIPTION
- Changing `aud` to be the URL of the FHIR resource server: aud parameter whose value is the URL of the FHIR resource server from which the app wishes to retrieve
- Added serverless version to `devDependencies` ensure 'supported'/'tested' version

From [SMART](https://docs.smarthealthit.org/authorization/best-practices/): `2.5.1 To prevent leakage of a genuine bearer token to a counterfeit resource server, the SMART on FHIR Authorization Guide requires that authorization requests include an aud parameter whose value is the URL of the FHIR resource server from which the app wishes to retrieve FHIR data. Authorization servers must validate that the aud parameter is the URL of a known and trusted resource server prior to returning an authorization code to the requester.`